### PR TITLE
A couple of changes

### DIFF
--- a/src/StrPack.jl
+++ b/src/StrPack.jl
@@ -153,6 +153,11 @@ function unpack{T}(in::IO, ::Type{T}, asize::Dict, strategy::DataAlign, endianne
         else
             typ
         end
+
+        # Skip padding before next field
+        pad = pad_next(offset,intyp,strategy) 
+        skip(in,pad)
+        offset += pad
         offset += if intyp <: String
             push!(rvar, rstrip(convert(typ, read(in, Uint8, dims...)), "\0"))
             prod(dims)

--- a/test/test.jl
+++ b/test/test.jl
@@ -25,6 +25,16 @@ end
     a::Array{Float64,2}(3,2)
 end
 
+abstract abstractG
+
+@struct type G1 <: abstractG
+a::Uint8
+end
+
+@struct immutable G2 <: abstractG
+a::Uint8
+end
+
 @struct type Hvl_t
     len::Csize_t
     p::Ptr{Void}
@@ -55,5 +65,8 @@ end
 @test roundtrip(E([C("a"); C("b")]))
 
 @test roundtrip(F([1. 2.; 3. 4.; 5. 6.]))
+
+@test roundtrip(G1(uint8(0)))
+@test roundtrip(G2(uint8(0)))
 
 @test roundtrip(Hvl_t(uint64(0), ccall(:jl_environ, Ptr{Void}, (Int,), 0)))


### PR DESCRIPTION
Two things I came across. 
- I made `@struct` work with types that have supertypes
- I added a convenience method to read/things with different endianness
- There was also a weird bug that made it randomly lose bytes. I removed the offending line, but I'm not sure what was intended as `skip` returns a boolean rather than an int. Could you have a look and see what that was actually supposed to do?
