### PR TITLE
Make this work on 0.6, drop support for 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,21 @@ Documentation
 =============
 More complete documentation can be found on [Read The Docs](https://strpackjl.readthedocs.org/en/latest/).
 
-Incompatible change in 0.6
-==========================
+Incompatible change for Julia v0.6
+==================================
 
 Note that the primary artifact of this package was the `@struct` macro. In Julia `v0.6`, `struct` is now a reserved word.
 This necessitates a change, hence the macro is now called `@str`. This change has been made since `v0.2.0` of this package.
-This means that any code that uses this package must be changed when running on Julia v0.6. 
+This means that any code that uses this package MUST be changed when running on Julia v0.6.
+
+This will typically require a v0.6-and-above only release of any package that is a dependency of this package. If you must
+support both Julia v0.5 and v0.6 in the same version, you'll have to have version-dependent code in your package; I would
+not recommend doing that.   
+
+Users on Julia `v0.5` can continue to use `v0.1.0` of this package without issues. 
 
 WARNING
 =======
 
-This package is only semi-maintained. While it has been updated to work without warnings on Julia 0.5,
+This package is only semi-maintained. While it has been updated to work without warnings on Julia 0.6,
 there are no guarantees of correctness beyond the existing package tests. Use at your own risk.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Documentation
 =============
 More complete documentation can be found on [Read The Docs](https://strpackjl.readthedocs.org/en/latest/).
 
+Incompatible change in 0.6
+==========================
+
+Note that the primary artifact of this package was the `@struct` macro. In Julia `v0.6`, `struct` is now a reserved word.
+This necessitates a change, hence the macro is now called `@str`. This change has been made since `v0.2.0` of this package.
+This means that any code that uses this package must be changed when running on Julia v0.6. 
+
 WARNING
 =======
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.4.5
+julia 0.6

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,7 +18,7 @@ Let's create a C library as follows:
       int      int1;
       float    float1;
     };
-    
+
     void getvalues(struct teststruct* ts)
     {
       ts->int1 = 7;
@@ -32,7 +32,7 @@ Let's also create the Julia analog of this structure::
 
     using StrPack
 
-    @struct type TestStruct
+    @str type TestStruct
         int1::Int32
         float1::Float32
     end
@@ -44,7 +44,7 @@ Let's also create the Julia analog of this structure::
 Note that C's ``int`` corresponds to ``Int32``. Let's initialize an object of this type::
 
     s = TestStruct(-1, 1.2)
-    
+
 We can pack ``s`` into a form suitable to pass as the input to our C function ``getvalues``, which we do in the
 following way::
 
@@ -78,11 +78,11 @@ Voila! You have the result back.
 Macros
 ------
 
-.. function:: @struct(type, strategy, endianness)
+.. function:: @str(type, strategy, endianness)
 
     Create and register a structural Julia type with StrPack. The type argument uses an extended form of the standard Julia type syntax to define the size of arrays and strings. Each element must declare its type, and each type must be reducible to a bits type or array or composite of bits types.::
 
-        @struct type StructuralType
+        @str type StructuralType
             a::Float64 # a bits type
             b::Array{Int32,2}(4, 4) # an array of bits types
             c::ASCIIString(8) # a string with a fixed number of bytes
@@ -94,16 +94,16 @@ Methods
 
 .. function:: pack(io, composite[, asize, strategy, endianness])
 
-    Create a packed buffer representation of ``composite`` in stream ``io``, using array and string sizes fixed by ``asize`` and data alignment coded by ``strategy`` with endianness ``endianness``. If the optional arguments are not provided, then ``T``, the type of ``composite``, is expected to have been created with the ``@struct`` macro.
-    
+    Create a packed buffer representation of ``composite`` in stream ``io``, using array and string sizes fixed by ``asize`` and data alignment coded by ``strategy`` with endianness ``endianness``. If the optional arguments are not provided, then ``T``, the type of ``composite``, is expected to have been created with the ``@str`` macro.
+
 .. function:: unpack(io, T[, asize, strategy, endianness])
 
     Extract an instance of the Julia composite type ``T`` from the packed representation in the stream ``io``.
-    If the optional arguments are not provided, then ``T`` is expected to have been created with the ``@struct`` macro.
+    If the optional arguments are not provided, then ``T`` is expected to have been created with the ``@str`` macro.
 
 .. function:: show_struct_layout(T[, asize, strategy][, width, bytesize])
 
-    Print a graphical representation of the memory layout of the packed type ``T``. If ``asize`` and ``strategy`` are not provided, then ``T`` is expected to have been created with the ``@struct`` macro. The display will show ``width`` bytes in each row, with each byte taking up ``bytesize`` characters.
+    Print a graphical representation of the memory layout of the packed type ``T``. If ``asize`` and ``strategy`` are not provided, then ``T`` is expected to have been created with the ``@str`` macro. The display will show ``width`` bytes in each row, with each byte taking up ``bytesize`` characters.
 
 ----------
 Endianness

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,41 +1,41 @@
 using Base.Test
 using StrPack
 
-@struct type A
+@str type A
     a::UInt8
 end
 
-@struct type B
+@str type B
     a::Array{UInt8,2}(2,2)
 end
 
-@struct type C
+@str type C
     a::String(5)
 end
 
-@struct type D
+@str type D
     a::C
 end
 
-@struct type E
+@str type E
     a::Array{C,1}(2)
 end
 
-@struct immutable F
+@str immutable F
     a::Array{Float64,2}(3,2)
 end
 
-abstract abstractG
+abstract type abstractG; end
 
-@struct type G1 <: abstractG
+@str type G1 <: abstractG
   a::UInt8
 end
 
-@struct immutable G2 <: abstractG
+@str immutable G2 <: abstractG
   a::UInt8
 end
 
-@struct type Hvl_t
+@str type Hvl_t
     len::Csize_t
     p::Ptr{Void}
 end


### PR DESCRIPTION
Fix #30 

`@struct` becomes `@str`. There is no deprecation, and this version of code will not work in Julia `v0.5` and below. 

Code using this package will have to re-written,  but since it is currently breaking, this seems reasonable. 